### PR TITLE
Added environment variables for apcupsd.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 LABEL Greg Ewing (https://github.com/gregewing)
 ENV LANG=C.UTF-8 DEBIAN_FRONTEND=noninteractive
-ENV TZ=Europe/London
+# ENV TZ=Europe/London
 
 COPY scripts /usr/local/bin
 COPY start.sh /
@@ -10,7 +10,7 @@ RUN echo Starting. \
 # && cp /etc/apt/sources.list /etc/apt/sources.list.default \
 # && mv /usr/local/bin/sources.list.localrepo /etc/apt/sources.list \
  && apt-get -q -y update \
- && apt-get -q -y install --no-install-recommends apcupsd dbus libapparmor1 libdbus-1-3 libexpat1 \
+ && apt-get -q -y install --no-install-recommends apcupsd dbus libapparmor1 libdbus-1-3 libexpat1 tzdata \
  && apt-get -q -y full-upgrade \
  && rm -rif /var/lib/apt/lists/* \
  # && mv /usr/local/bin/apcupsd      /etc/default/apcupsd \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,10 @@ RUN echo Starting. \
  && apt-get -q -y install --no-install-recommends apcupsd dbus libapparmor1 libdbus-1-3 libexpat1 tzdata \
  && apt-get -q -y full-upgrade \
  && rm -rif /var/lib/apt/lists/* \
- && mv /usr/local/bin/apcupsd         /etc/default/apcupsd \
- && mv /usr/local/bin/apcupsd.conf    /etc/apcupsd/apcupsd.conf \
- && mv /usr/local/bin/hosts.conf      /etc/apcupsd/hosts.conf \
- && mv /usr/local/bin/doshutdown      /etc/apcupsd/doshutdown \
+# && mv /usr/local/bin/apcupsd         /etc/default/apcupsd \
+# && mv /usr/local/bin/apcupsd.conf    /etc/apcupsd/apcupsd.conf \
+# && mv /usr/local/bin/hosts.conf      /etc/apcupsd/hosts.conf \
+# && mv /usr/local/bin/doshutdown      /etc/apcupsd/doshutdown \
  && echo Finished.
 
-CMD ["/sbin/apcupsd", "-b"]
+CMD /start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM ubuntu:latest
-MAINTAINER Greg Ewing (https://github.com/gregewing)
+LABEL Greg Ewing (https://github.com/gregewing)
 ENV LANG=C.UTF-8 DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/London
 
 COPY scripts /usr/local/bin
+COPY start.sh /
 
 RUN echo Starting. \
 # && cp /etc/apt/sources.list /etc/apt/sources.list.default \
@@ -12,12 +13,12 @@ RUN echo Starting. \
  && apt-get -q -y install --no-install-recommends apcupsd dbus libapparmor1 libdbus-1-3 libexpat1 \
  && apt-get -q -y full-upgrade \
  && rm -rif /var/lib/apt/lists/* \
- && mv /usr/local/bin/apcupsd      /etc/default/apcupsd \
- && mv /usr/local/bin/apcupsd.conf /etc/apcupsd/apcupsd.conf \
- && mv /usr/local/bin/hosts.conf   /etc/apcupsd/hosts.conf \
- && mv /usr/local/bin/doshutdown      /etc/apcupsd/doshutdown \
+ # && mv /usr/local/bin/apcupsd      /etc/default/apcupsd \
+ # && mv /usr/local/bin/apcupsd.conf /etc/apcupsd/apcupsd.conf \
+ # && mv /usr/local/bin/hosts.conf   /etc/apcupsd/hosts.conf \
+ # && mv /usr/local/bin/doshutdown   /etc/apcupsd/doshutdown \
 ###  Revert to default repositories  ###
 # && mv /etc/apt/sources.list.default /etc/apt/sources.list \
  && echo Finished.
 
-CMD ["/sbin/apcupsd", "-b"]
+CMD /start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN echo Starting. \
  && apt-get -q -y install --no-install-recommends apcupsd dbus libapparmor1 libdbus-1-3 libexpat1 tzdata \
  && apt-get -q -y full-upgrade \
  && rm -rif /var/lib/apt/lists/* \
+ && rm -rf /etc/apcupsd/* \
 # && mv /usr/local/bin/apcupsd         /etc/default/apcupsd \
 # && mv /usr/local/bin/apcupsd.conf    /etc/apcupsd/apcupsd.conf \
 # && mv /usr/local/bin/hosts.conf      /etc/apcupsd/hosts.conf \

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ docker run -it —privileged \
   gregewing/apcupsd:latest
 ```
 
-And, for those using tools with docker-compose, here's an example. If you create the directory you want to bind to /etc/apcupsd in advance, and populate it with an apcupsd.conf file, then apcupsd should be functional the first time you launch the container:
-
+And, for those using tools with docker-compose (like Portainer), here's an example compose:
 ```yml
 version: '3.7'
 services:
@@ -39,14 +38,20 @@ services:
       - /dev/usb/hiddev0
     ports:
       - 3551:3551
-    environment:
-      - TZ=US/Mountain
+    environment: # Delete or comment out any environment variables you don't wish to change
+      - UPSNAME=${UPSNAME} # This value will display in apcupsd-cgi details.
+      - UPSCABLE=${UPSCABLE} # Default value is usb
+      - UPSTYPE=${UPSTYPE} # Default value is usb
+      - DEVICE=${DEVICE} # Default value is <blank>
+      - NETSERVER=${NETSERVER} # Default value is on
+      - NISIP=${NISIP} # Default value is 0.0.0.0
+      - TZ=${TZ} # Default value is Europe/London
     volumes:
       - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
       - /data/apcupsd:/etc/apcupsd
     restart: unless-stopped
 ```
-<br>
+Environment variables can be hardcoded into the above docker-compose, or added in the environment section of tool like Portainer. 
 
 You will likely want to customise <code>/etc/apcupsd/apcupsd.conf</code> for each of the hosts that you run this container on, so it will need to be bind mounded for persistence purpoes.  I recommend setting the threshold for shutting down hosts not directly connected to the UPS a little higher than the host connected to the UPS, so that the remote hosts are able to shut down before the UPS Connected host is no longer available to provide signalling.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Other apcupsd images i've seen are for exporting monitoring data to grafana or p
 
 Very little configuration is currently required for this image to work, though you may be required to tweak the USB device that is passed through to your container by docker.
 
-```
+```console
 docker run -it —privileged \
   --name=apcupsd \
   -e TZ=Europe/London \

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,1 @@
+docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -f Dockerfile -t bnhf/apcupsd . --push --no-cache

--- a/start.sh
+++ b/start.sh
@@ -34,44 +34,44 @@ fi
 
 # Check if UPSNAME environment variable is set, and if so update apcupsd.conf
 if [ ! -z $UPSNAME ]; then
-  sed -i 's|^UPSNAME.*|UPSNAME '"$UPSNAME"'|' /etc/apcupsd/apcupsd.conf
-  echo "UPSNAME set to: \"$UPSNAME\""
+  sed -i 's|^UPSNAME.*|UPSNAME '"$UPSNAME"'|' /etc/apcupsd/apcupsd.conf \
+  && echo "UPSNAME set to: \"$UPSNAME\""
 fi
 
 # Check if UPSCABLE environment variable is set, and if so update apcupsd.conf
 if [ ! -z $UPSCABLE ]; then
-  sed -i 's|^UPSCABLE.*|UPSCABLE '"$UPSCABLE"'|' /etc/apcupsd/apcupsd.conf
-  echo "UPSCABLE set to: \"$UPSCABLE\""
+  sed -i 's|^UPSCABLE.*|UPSCABLE '"$UPSCABLE"'|' /etc/apcupsd/apcupsd.conf \
+  && echo "UPSCABLE set to: \"$UPSCABLE\""
 fi
 
 # Check if UPSTYPE environment variable is set, and if so update apcupsd.conf
 if [ ! -z $UPSTYPE ]; then
-  sed -i 's|^UPSTYPE.*|UPSTYPE '"$UPSTYPE"'|' /etc/apcupsd/apcupsd.conf
-  echo "UPSTYPE set to: \"$UPSTYPE\""
+  sed -i 's|^UPSTYPE.*|UPSTYPE '"$UPSTYPE"'|' /etc/apcupsd/apcupsd.conf \
+  && echo "UPSTYPE set to: \"$UPSTYPE\""
 fi
 
 # Check if DEVICE environment variable is set, and if so update apcupsd.conf
 if [ ! -z $DEVICE ]; then
-  sed -i 's|^#DEVICE /dev/tty0.*|DEVICE '"$DEVICE"'|' /etc/apcupsd/apcupsd.conf
-  echo "DEVICE set to: \"$DEVICE\""
+  sed -i 's|^#DEVICE /dev/tty0.*|DEVICE '"$DEVICE"'|' /etc/apcupsd/apcupsd.conf \
+  && echo "DEVICE set to: \"$DEVICE\""
 fi
 
 # Check if NETSERVER environment variable is set, and if so update apcupsd.conf
 if [ ! -z $NETSERVER ]; then
-  sed -i 's|^NETSERVER.*|NETSERVER '"$NETSERVER"'|' /etc/apcupsd/apcupsd.conf
-  echo "NETSERVER set to: \"$NETSERVER\""
+  sed -i 's|^NETSERVER.*|NETSERVER '"$NETSERVER"'|' /etc/apcupsd/apcupsd.conf \
+  && echo "NETSERVER set to: \"$NETSERVER\""
 fi
 
 # Check if NISIP environment variable is set, and if so update apcupsd.conf
 if [ ! -z $NISIP ]; then
-  sed -i 's|^NISIP.*|NISIP '"$NISIP"'|' /etc/apcupsd/apcupsd.conf
-  echo "NISIP set to: \"$NISIP\""
+  sed -i 's|^NISIP.*|NISIP '"$NISIP"'|' /etc/apcupsd/apcupsd.conf \
+  && echo "NISIP set to: \"$NISIP\""
 fi
 
 # Check if NISPORT environment variable is set, and if so update apcupsd.conf
 if [ ! -z $NISPORT ]; then
-  sed -i 's|^NISPORT.*|NISPORT '"$NISPORT"'|' /etc/apcupsd/apcupsd.conf
-  echo "NISPORT set to: \"$NISPORT\""
+  sed -i 's|^NISPORT.*|NISPORT '"$NISPORT"'|' /etc/apcupsd/apcupsd.conf \
+  && echo "NISPORT set to: \"$NISPORT\""
 fi
 
 /sbin/apcupsd -b

--- a/start.sh
+++ b/start.sh
@@ -16,7 +16,7 @@ fi
 
 # Check if hosts.conf already exists
 if [ ! -f /etc/apcupsd/hosts.conf ]; then
-  mv /usr/local/bin/hosts.conf /etc/default/hosts.conf \
+  mv /usr/local/bin/hosts.conf /etc/apcupsd/hosts.conf \
   && echo "No existing hosts.conf found"
 else
   rm /usr/local/bin/hosts.conf \
@@ -25,7 +25,7 @@ fi
 
 # Check if doshutdown already exists
 if [ ! -f /etc/apcupsd/doshutdown ]; then
-  mv /usr/local/bin/doshutdown /etc/default/doshutdown \
+  mv /usr/local/bin/doshutdown /etc/apcupsd/doshutdown \
   && echo "No existing doshutdown found"
 else
   rm /usr/local/bin/doshutdown \

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,60 @@
+#! /bin/bash
+
+# Config file moves transferred from Dockerfile to support
+# binding /etc/apcupsd to user-specified host directory
+
+# Check if apcupsd.conf already exists
+if [ ! -f /etc/apcupsd/apcupsd.conf ]; then
+  mv /usr/local/bin/apcupsd          /etc/default/apcupsd \
+  && mv /usr/local/bin/apcupsd.conf /etc/apcupsd/apcupsd.conf \
+  && mv /usr/local/bin/hosts.conf   /etc/apcupsd/hosts.conf \
+  && mv /usr/local/bin/doshutdown   /etc/apcupsd/doshutdown
+else
+  mv /usr/local/bin/apcupsd          /etc/default/apcupsd \
+  && mv /usr/local/bin/hosts.conf   /etc/apcupsd/hosts.conf \
+  && mv /usr/local/bin/doshutdown   /etc/apcupsd/doshutdown
+fi
+
+# Check if UPSNAME environment variable is set, and if so update apcupsd.conf
+if [ ! -z $UPSNAME ]; then
+  sed -i 's|^UPSNAME.*|UPSNAME '"$UPSNAME"'|' /etc/apcupsd/apcupsd.conf
+  echo "UPSNAME set to: \"$UPSNAME\""
+fi
+
+# Check if UPSCABLE environment variable is set, and if so update apcupsd.conf
+if [ ! -z $UPSCABLE ]; then
+  sed -i 's|^UPSCABLE.*|UPSCABLE '"$UPSCABLE"'|' /etc/apcupsd/apcupsd.conf
+  echo "UPSCABLE set to: \"$UPSCABLE\""
+fi
+
+# Check if UPSTYPE environment variable is set, and if so update apcupsd.conf
+if [ ! -z $UPSTYPE ]; then
+  sed -i 's|^UPSTYPE.*|UPSTYPE '"$UPSTYPE"'|' /etc/apcupsd/apcupsd.conf
+  echo "UPSTYPE set to: \"$UPSTYPE\""
+fi
+
+# Check if DEVICE environment variable is set, and if so update apcupsd.conf
+if [ ! -z $DEVICE ]; then
+  sed -i 's|^#DEVICE /dev/tty0.*|DEVICE '"$DEVICE"'|' /etc/apcupsd/apcupsd.conf
+  echo "DEVICE set to: \"$DEVICE\""
+fi
+
+# Check if NETSERVER environment variable is set, and if so update apcupsd.conf
+if [ ! -z $NETSERVER ]; then
+  sed -i 's|^NETSERVER.*|NETSERVER '"$NETSERVER"'|' /etc/apcupsd/apcupsd.conf
+  echo "NETSERVER set to: \"$NETSERVER\""
+fi
+
+# Check if NISIP environment variable is set, and if so update apcupsd.conf
+if [ ! -z $NISIP ]; then
+  sed -i 's|^NISIP.*|NISIP '"$NISIP"'|' /etc/apcupsd/apcupsd.conf
+  echo "NISIP set to: \"$NISIP\""
+fi
+
+# Check if NISPORT environment variable is set, and if so update apcupsd.conf
+if [ ! -z $NISPORT ]; then
+  sed -i 's|^NISPORT.*|NISPORT '"$NISPORT"'|' /etc/apcupsd/apcupsd.conf
+  echo "NISPORT set to: \"$NISPORT\""
+fi
+
+/sbin/apcupsd -b

--- a/start.sh
+++ b/start.sh
@@ -5,16 +5,26 @@
 
 # Check if apcupsd.conf already exists
 if [ ! -f /etc/apcupsd/apcupsd.conf ]; then
-  mv /usr/local/bin/apcupsd          /etc/default/apcupsd \
-  && mv /usr/local/bin/apcupsd.conf /etc/apcupsd/apcupsd.conf \
-  && mv /usr/local/bin/hosts.conf   /etc/apcupsd/hosts.conf \
-  && mv /usr/local/bin/doshutdown   /etc/apcupsd/doshutdown
+  mv /usr/local/bin/apcupsd /etc/default/apcupsd \
+  && mv /usr/local/bin/apcupsd.conf /etc/apcupsd/apcupsd.conf 
 else
-  mv /usr/local/bin/apcupsd          /etc/default/apcupsd \
-  && mv /usr/local/bin/hosts.conf   /etc/apcupsd/hosts.conf \
-  && mv /usr/local/bin/doshutdown   /etc/apcupsd/doshutdown
+  mv /usr/local/bin/apcupsd /etc/default/apcupsd \
+  && rm /usr/local/bin/apcupsd.conf
 fi
 
+# Check if hosts.conf already exists
+if [ ! -f /etc/apcupsd/hosts.conf ]; then
+  mv /usr/local/bin/hosts.conf /etc/default/hosts.conf
+else
+  rm /usr/local/bin/hosts.conf
+fi
+
+# Check if doshutdown already exists
+if [ ! -f /etc/apcupsd/doshutdown ]; then
+  mv /usr/local/bin/doshutdown /etc/default/doshutdown
+else
+  rm /usr/local/bin/doshutdown
+fi
 # Check if UPSNAME environment variable is set, and if so update apcupsd.conf
 if [ ! -z $UPSNAME ]; then
   sed -i 's|^UPSNAME.*|UPSNAME '"$UPSNAME"'|' /etc/apcupsd/apcupsd.conf

--- a/start.sh
+++ b/start.sh
@@ -6,25 +6,32 @@
 # Check if apcupsd.conf already exists
 if [ ! -f /etc/apcupsd/apcupsd.conf ]; then
   mv /usr/local/bin/apcupsd /etc/default/apcupsd \
-  && mv /usr/local/bin/apcupsd.conf /etc/apcupsd/apcupsd.conf 
-else
+  && mv /usr/local/bin/apcupsd.conf /etc/apcupsd/apcupsd.conf \
+  && echo "No existing apcupsd.conf found"
+  else
   mv /usr/local/bin/apcupsd /etc/default/apcupsd \
-  && rm /usr/local/bin/apcupsd.conf
+  && rm /usr/local/bin/apcupsd.conf \
+  && echo "Existing apcupsd.conf found, and will be used"
 fi
 
 # Check if hosts.conf already exists
 if [ ! -f /etc/apcupsd/hosts.conf ]; then
-  mv /usr/local/bin/hosts.conf /etc/default/hosts.conf
+  mv /usr/local/bin/hosts.conf /etc/default/hosts.conf \
+  && echo "No existing hosts.conf found"
 else
-  rm /usr/local/bin/hosts.conf
+  rm /usr/local/bin/hosts.conf \
+  && echo "Existing hosts.conf found, and will be used"
 fi
 
 # Check if doshutdown already exists
 if [ ! -f /etc/apcupsd/doshutdown ]; then
-  mv /usr/local/bin/doshutdown /etc/default/doshutdown
+  mv /usr/local/bin/doshutdown /etc/default/doshutdown \
+  && echo "No existing doshutdown found"
 else
-  rm /usr/local/bin/doshutdown
+  rm /usr/local/bin/doshutdown \
+  && echo "Existing doshutdown found, and will be used"
 fi
+
 # Check if UPSNAME environment variable is set, and if so update apcupsd.conf
 if [ ! -z $UPSNAME ]; then
   sed -i 's|^UPSNAME.*|UPSNAME '"$UPSNAME"'|' /etc/apcupsd/apcupsd.conf


### PR DESCRIPTION
A number of minor changes in this PR:

A start.sh script is now in place allowing for the addition of environment variables. A custom apcupsd.conf can be used through a host binding, or the environment variables will modify a container version of that file if a binding is not used.

Files in the ./scripts directory are now conditionally moved in start.sh rather than the Dockerfile to support use of a persistent bound directory for these data files.

All files except for the README.md have been modified to remove CR-LF combos, and replace them with Linux standard LF only.

A build.sh file has been added with the syntax for a buildx multi-arch build. This file is mostly for copy-and-paste use of the buildx command line, and should be modified as required for CPU architectures and target Docker Hub repositories and tags.